### PR TITLE
feat: terraria prism big laser

### DIFF
--- a/TerraAngelPatches/Terraria/Projectile.cs.patch
+++ b/TerraAngelPatches/Terraria/Projectile.cs.patch
@@ -1,5 +1,13 @@
 --- src/Terraria/Terraria/Projectile.cs
 +++ src/TerraAngel/Terraria/Projectile.cs
+@@ -3,6 +_,7 @@
+ using Microsoft.Xna.Framework;
+ using Microsoft.Xna.Framework.Audio;
+ using ReLogic.Utilities;
++using TerraAngel.Tools.Exploit;
+ using Terraria.Audio;
+ using Terraria.Chat;
+ using Terraria.DataStructures;
 @@ -20118,6 +_,7 @@
              flag = true;
          }
@@ -64,6 +72,72 @@
              rotation = rotation.AngleLerp(idleRotation3, 0.45f);
              if (Main.rand.Next(20) == 0)
              {
+@@ -68518,7 +_,17 @@
+                 num37 = 5f;
+             }
+ 
++            if (ToolManager.GetTool<TerrariaPrismTool>().IsToolProjectile(whoAmI))
++            {
++                if (velocity == Vector2.Zero)
++                {
++                    velocity = -Vector2.UnitY;
++                }
++            }
++            else
++            {
+-            damage = (int)((float)player.inventory[player.selectedItem].damage * player.magicDamage);
++                damage = (int)((float)player.inventory[player.selectedItem].damage * player.magicDamage);
++            }
+             ai[0] += 1f;
+             ai[1] += 1f;
+             bool flag8 = false;
+@@ -68538,7 +_,7 @@
+             {
+                 ai[1] = 0f;
+                 flag9 = true;
+-                if (Main.myPlayer == owner)
++                if (Main.myPlayer == owner && !ToolManager.GetTool<TerrariaPrismTool>().IsToolProjectile(whoAmI))
+                 {
+                     float num39 = player.inventory[player.selectedItem].shootSpeed * scale;
+                     Vector2 vector18 = vector;
+@@ -68588,20 +_,33 @@
+ 
+             if (flag9 && Main.myPlayer == owner)
+             {
+-                bool flag10 = false;
+-                flag10 = !flag8 || player.CheckMana(player.inventory[player.selectedItem].mana, pay: true);
+-                if (player.channel && flag10 && !player.noItems && !player.CCed)
++                bool flag10 = !flag8 || player.CheckMana(player.inventory[player.selectedItem].mana, pay: true);
++                if (ToolManager.GetTool<TerrariaPrismTool>().IsToolProjectile(whoAmI))
++                {
++                    if (ai[0] == 181f)
++                    {
++                        Vector2 center2 = base.Center;
++                        int num41 = damage;
++                        for (int m = 0; m < 6; m++)
++                        {
++                            var index = NewProjectile(GetProjectileSource_FromThis(), center2.X, center2.Y, velocity.X, velocity.Y, 632, num41, knockBack, owner, m, whoAmI);
++                            Main.projectile[index].timeLeft = int.MaxValue;
++                        }
++                        netUpdate = true;
++                    }
++                }
++                else if (player.channel && flag10 && !player.noItems && !player.CCed)
+                 {
+                     if (ai[0] == 1f)
+                     {
+                         Vector2 center2 = base.Center;
++                        int num41 = damage;
+                         Vector2 vector19 = Vector2.Normalize(velocity);
+                         if (float.IsNaN(vector19.X) || float.IsNaN(vector19.Y))
+                         {
+                             vector19 = -Vector2.UnitY;
+                         }
+ 
+-                        int num41 = damage;
+                         for (int m = 0; m < 6; m++)
+                         {
+                             NewProjectile(GetProjectileSource_FromThis(), center2.X, center2.Y, vector19.X, vector19.Y, 632, num41, knockBack, owner, m, whoAmI);
 @@ -79444,7 +_,7 @@
                                  Vector2 value13 = vector73.RotatedBy(((num904 == 0) ? 1f : (-1f)) * ((float)Math.PI * 2f) / (num899 * 2f));
                                  for (float num905 = 0f; num905 < num902; num905++)

--- a/TerraAngelPatches/Terraria/Projectile.cs.patch
+++ b/TerraAngelPatches/Terraria/Projectile.cs.patch
@@ -1,13 +1,5 @@
 --- src/Terraria/Terraria/Projectile.cs
 +++ src/TerraAngel/Terraria/Projectile.cs
-@@ -3,6 +_,7 @@
- using Microsoft.Xna.Framework;
- using Microsoft.Xna.Framework.Audio;
- using ReLogic.Utilities;
-+using TerraAngel.Tools.Exploit;
- using Terraria.Audio;
- using Terraria.Chat;
- using Terraria.DataStructures;
 @@ -20118,6 +_,7 @@
              flag = true;
          }
@@ -16,6 +8,38 @@
          if (!flag && fisher.inLava)
          {
              int num3 = 0;
+@@ -32249,6 +_,31 @@
+             }
+ 
+             localAI[1] = MathHelper.Lerp(localAI[1], num734, amount);
++
++            // TerraAngel: Break tiles when laser touches them (if enabled in TerrariaPrismTool)
++            if (type == 632 && Main.projectile[(int)this.ai[1]].active && Main.projectile[(int)this.ai[1]].type == 633)
++            {
++                var prismTool = ToolManager.GetTool<TerraAngel.Tools.Exploit.TerrariaPrismTool>();
++                if (prismTool.ShouldBreakTiles())
++                {
++                    // Calculate the end point of the laser
++                    Vector2 laserEnd = base.Center + velocity * localAI[1];
++                    int tileX = (int)(laserEnd.X / 16f);
++                    int tileY = (int)(laserEnd.Y / 16f);
++
++                    for (int x = tileX - 1; x <= tileX + 1; x++)
++                    {
++                        for (int y = tileY - 1; y <= tileY + 1; y++)
++                        {
++                            if (WorldGen.InWorld(x, y) && Main.tile[x, y].active())
++                            {
++                                WorldGen.KillTile(x, y);
++                            }
++                        }
++                    }
++                }
++            }
++
+             if (type == 455)
+             {
+                 Vector2 vector64 = base.Center + velocity * (localAI[1] - 14f);
 @@ -38871,8 +_,8 @@
          Vector2 value = master.MountedCenter + new Vector2(master.direction * 10, 0f);
          Vector2 tangent = new Vector2(0f, -100f);
@@ -76,7 +100,7 @@
                  num37 = 5f;
              }
  
-+            if (ToolManager.GetTool<TerrariaPrismTool>().IsToolProjectile(whoAmI))
++            if (ToolManager.GetTool<TerraAngel.Tools.Exploit.TerrariaPrismTool>().IsToolProjectile(whoAmI))
 +            {
 +                if (velocity == Vector2.Zero)
 +                {
@@ -85,8 +109,7 @@
 +            }
 +            else
 +            {
--            damage = (int)((float)player.inventory[player.selectedItem].damage * player.magicDamage);
-+                damage = (int)((float)player.inventory[player.selectedItem].damage * player.magicDamage);
+             damage = (int)((float)player.inventory[player.selectedItem].damage * player.magicDamage);
 +            }
              ai[0] += 1f;
              ai[1] += 1f;
@@ -96,19 +119,15 @@
                  ai[1] = 0f;
                  flag9 = true;
 -                if (Main.myPlayer == owner)
-+                if (Main.myPlayer == owner && !ToolManager.GetTool<TerrariaPrismTool>().IsToolProjectile(whoAmI))
++                if (Main.myPlayer == owner && !ToolManager.GetTool<TerraAngel.Tools.Exploit.TerrariaPrismTool>().IsToolProjectile(whoAmI))
                  {
                      float num39 = player.inventory[player.selectedItem].shootSpeed * scale;
                      Vector2 vector18 = vector;
-@@ -68588,20 +_,33 @@
- 
-             if (flag9 && Main.myPlayer == owner)
+@@ -68590,7 +_,21 @@
              {
--                bool flag10 = false;
--                flag10 = !flag8 || player.CheckMana(player.inventory[player.selectedItem].mana, pay: true);
--                if (player.channel && flag10 && !player.noItems && !player.CCed)
-+                bool flag10 = !flag8 || player.CheckMana(player.inventory[player.selectedItem].mana, pay: true);
-+                if (ToolManager.GetTool<TerrariaPrismTool>().IsToolProjectile(whoAmI))
+                 bool flag10 = false;
+                 flag10 = !flag8 || player.CheckMana(player.inventory[player.selectedItem].mana, pay: true);
++                if (ToolManager.GetTool<TerraAngel.Tools.Exploit.TerrariaPrismTool>().IsToolProjectile(whoAmI))
 +                {
 +                    if (ai[0] == 181f)
 +                    {
@@ -122,22 +141,19 @@
 +                        netUpdate = true;
 +                    }
 +                }
+-                if (player.channel && flag10 && !player.noItems && !player.CCed)
 +                else if (player.channel && flag10 && !player.noItems && !player.CCed)
                  {
                      if (ai[0] == 1f)
                      {
-                         Vector2 center2 = base.Center;
-+                        int num41 = damage;
-                         Vector2 vector19 = Vector2.Normalize(velocity);
-                         if (float.IsNaN(vector19.X) || float.IsNaN(vector19.Y))
+@@ -68600,7 +_,6 @@
                          {
                              vector19 = -Vector2.UnitY;
                          }
- 
--                        int num41 = damage;
+-
+                         int num41 = damage;
                          for (int m = 0; m < 6; m++)
                          {
-                             NewProjectile(GetProjectileSource_FromThis(), center2.X, center2.Y, vector19.X, vector19.Y, 632, num41, knockBack, owner, m, whoAmI);
 @@ -79444,7 +_,7 @@
                                  Vector2 value13 = vector73.RotatedBy(((num904 == 0) ? 1f : (-1f)) * ((float)Math.PI * 2f) / (num899 * 2f));
                                  for (float num905 = 0f; num905 < num902; num905++)

--- a/TerraAngelPatches/Terraria/TerraAngel/Tools/Exploit/TerrariaPrismTool.cs
+++ b/TerraAngelPatches/Terraria/TerraAngel/Tools/Exploit/TerrariaPrismTool.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+namespace TerraAngel.Tools.Exploit;
+
+public class TerrariaPrismTool : Tool
+{
+    public override string Name => GetString("TerrariaPrism Tool");
+
+    public override ToolTabs Tab => ToolTabs.MiscTools;
+
+    private bool _fireLaser;
+
+    private int _damage = 200;
+
+    private readonly HashSet<int> _projectiles = [];
+
+    public override void DrawUI(ImGuiIOPtr io)
+    {
+        ImGui.PushID(nameof(TerrariaPrismTool));
+
+        if (ImGui.CollapsingHeader(GetString("TerrariaPrism")))
+        {
+            if(ImGui.Checkbox(GetString("Enable"), ref _fireLaser))
+            {
+                if (_fireLaser)
+                {
+                    for (var dir = 0; dir < 8; dir++)
+                    {
+                        var angle = dir * (float)Math.PI / 4f;
+                        var direction = new Vector2((float)Math.Sin(angle), -(float)Math.Cos(angle));
+                        var projIndex = Projectile.NewProjectile(Projectile.GetNoneSource(), Main.LocalPlayer.Center, direction, ProjectileID.LastPrism, _damage, 10, Main.myPlayer, 180f, 0f, 0f);
+                        _projectiles.Add(projIndex);
+                    }
+                }
+                else
+                {
+                    _projectiles.Clear();
+                }
+            }
+
+            if (ImGui.SliderInt("Damage", ref _damage, 1, 1000) && _projectiles.Count > 0)
+            {
+                foreach (var index in _projectiles)
+                {
+                    Main.projectile[index].damage = _damage;
+                }
+            }
+        }
+
+        ImGui.PopID();
+    }
+
+    public bool IsToolProjectile(int projectileIndex)
+    {
+        return _projectiles.Contains(projectileIndex);
+    }
+}

--- a/TerraAngelPatches/Terraria/TerraAngel/Tools/Exploit/TerrariaPrismTool.cs
+++ b/TerraAngelPatches/Terraria/TerraAngel/Tools/Exploit/TerrariaPrismTool.cs
@@ -39,7 +39,7 @@ public class TerrariaPrismTool : Tool
                 }
             }
 
-            if (ImGui.SliderInt("Damage", ref _damage, 1, 1000) && _projectiles.Count > 0)
+            if (ImGui.SliderInt(GetString("Damage"), ref _damage, 1, 1000) && _projectiles.Count > 0)
             {
                 foreach (var index in _projectiles)
                 {

--- a/TerraAngelPatches/Terraria/TerraAngel/Tools/Exploit/TerrariaPrismTool.cs
+++ b/TerraAngelPatches/Terraria/TerraAngel/Tools/Exploit/TerrariaPrismTool.cs
@@ -13,6 +13,8 @@ public class TerrariaPrismTool : Tool
 
     private int _damage = 200;
 
+    private bool _breakTiles = true;
+
     private readonly HashSet<int> _projectiles = [];
 
     public override void DrawUI(ImGuiIOPtr io)
@@ -46,6 +48,8 @@ public class TerrariaPrismTool : Tool
                     Main.projectile[index].damage = _damage;
                 }
             }
+
+            ImGui.Checkbox(GetString("Break Tiles"), ref _breakTiles);
         }
 
         ImGui.PopID();
@@ -54,5 +58,10 @@ public class TerrariaPrismTool : Tool
     public bool IsToolProjectile(int projectileIndex)
     {
         return _projectiles.Contains(projectileIndex);
+    }
+
+    public bool ShouldBreakTiles()
+    {
+        return _breakTiles;
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

添加一个新的杂项利用工具，在本地玩家周围生成并管理一圈 Last Prism 激光弹幕。

新特性：
- 引入 `TerrariaPrismTool`，可以通过工具界面切换 Last Prism 激光效果，并跟踪其生成的弹幕。

增强内容：
- 通过工具内滑块，允许动态调整所有激活的 `TerrariaPrismTool` 弹幕的伤害值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new miscellaneous exploit tool that spawns and manages a ring of Last Prism laser projectiles around the local player.

New Features:
- Introduce TerrariaPrismTool to toggle a Last Prism laser effect via the tools UI and track its spawned projectiles.

Enhancements:
- Allow dynamic adjustment of damage for all active TerrariaPrismTool projectiles through an in‑tool slider.

</details>