### PR TITLE
fix: bug that prevents joining servers via steam

### DIFF
--- a/TerraAngelPatches/Terraria/Net/Sockets/SocialSocket.cs.patch
+++ b/TerraAngelPatches/Terraria/Net/Sockets/SocialSocket.cs.patch
@@ -1,0 +1,32 @@
+--- src/Terraria/Terraria/Net/Sockets/SocialSocket.cs
++++ src/TerraAngel/Terraria/Net/Sockets/SocialSocket.cs
+@@ -1,10 +_,10 @@
+ using System.Threading;
++using System.Threading.Tasks;
+ using Terraria.Social;
+ 
+ namespace Terraria.Net.Sockets;
+ public class SocialSocket : ISocket
+ {
+-    private delegate void InternalReadCallback(byte[] data, int offset, int size, SocketReceiveCallback callback, object state);
+     private RemoteAddress _remoteAddress;
+     public SocialSocket()
+     {
+@@ -38,7 +_,7 @@
+     void ISocket.AsyncSend(byte[] data, int offset, int size, SocketSendCallback callback, object state)
+     {
+         SocialAPI.Network.Send(_remoteAddress, data, size);
+-        callback.BeginInvoke(state, null, null);
++        Task.Run(() => callback(state));
+     }
+ 
+     private void ReadCallback(byte[] data, int offset, int size, SocketReceiveCallback callback, object state)
+@@ -54,7 +_,7 @@
+ 
+     void ISocket.AsyncReceive(byte[] data, int offset, int size, SocketReceiveCallback callback, object state)
+     {
+-        new InternalReadCallback(ReadCallback).BeginInvoke(data, offset, size, callback, state, null, null);
++        Task.Run(() => ReadCallback(data, offset, size, callback, state));
+     }
+ 
+     bool ISocket.IsDataAvailable()


### PR DESCRIPTION
## Summary by Sourcery

修复 Steam 社交套接字处理，以允许通过 Steam 加入服务器，并为 SocialSocket 添加补丁脚手架。

Bug Fixes:
- 解决由于社交套接字行为不正确导致无法通过 Steam 加入服务器的问题。

Enhancements:
- 为 SocialSocket 网络组件引入补丁文件，以支持基于 Steam 的连接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Steam social socket handling to allow joining servers via Steam and add patch scaffolding for SocialSocket.

Bug Fixes:
- Resolve an issue where joining servers via Steam would fail due to incorrect social socket behavior.

Enhancements:
- Introduce a patch file for the SocialSocket networking component to support Steam-based connections.

</details>